### PR TITLE
Support router solicitation without SLLA option

### DIFF
--- a/netlink.h
+++ b/netlink.h
@@ -8,3 +8,4 @@ int netlink_disassociate(int ifindex, const unsigned char *mac,
                          const unsigned char *mymac);
 int netlink_route(int ifindex, int add, int ipv6,
                   const unsigned char *dst, int dlen);
+int nl_get_mac(int ifindex, unsigned char * dst, unsigned char * mac);

--- a/ra.h
+++ b/ra.h
@@ -35,5 +35,6 @@ int send_ra(const unsigned char *prefix, int tm,
             const struct sockaddr_in6 *to, struct interface *interface);
 int receive_rs(void);
 int send_gratuitous_na(struct interface *interface);
+int send_ns(struct interface *interface, unsigned char * ipv6);
 
 


### PR DESCRIPTION
Hello,

I have been testing sroamd for some days as part of my work at Nexedi and I found out my Android 14 phone could connect and configure IPv6 correctly to nodes running sroamd but not my Ubuntu 22 laptop. I found out that many devices do not include their MAC address in router solicitations ( https://github.com/radvd-project/radvd/issues/63#issuecomment-287172252 ), so I am suggesting this change to support such devices.
With this change devices who do not include MAC address will need to send two router sollicitations before receiving a router advertisment if their MAC address is not yet known to the router. We could do better and send the RA as soon as we receive we the NA but I didn't find any easy and nice way to do this. (this would imply either listening to NA and remembering some context, or sleeping for a short time after send_ns and getting the MAC address right after)

I tested this with two routers running babeld+hostapd+sroamd, one laptop connecting to the roaming wifi, and another laptop running babeld on the same LAN (through ethernet). Then I used iwconfig to increase and decrease the TX gains on both stations to simulate the laptop moving between the two, and did a TCP iperf3 test between both laptops and checked that the TCP session could survive switching between both wifi AP